### PR TITLE
Fix typo in notebook

### DIFF
--- a/intro-to-rnns/Anna KaRNNa.ipynb
+++ b/intro-to-rnns/Anna KaRNNa.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Looking at the size of this array, we see that we have rows equal to the batch size. When we want to get a batch out of here, we can grab a subset of this arrow that contains all the rows but has a width equal to the number of steps in the sequence. The first batch looks like this:"
+    "Looking at the size of this array, we see that we have rows equal to the batch size. When we want to get a batch out of here, we can grab a subset of this array that contains all the rows but has a width equal to the number of steps in the sequence. The first batch looks like this:"
    ]
   },
   {


### PR DESCRIPTION
`arrow` -> `array`