### PR TITLE
Remove extraneous `return`

### DIFF
--- a/image-classification/problem_unittests.py
+++ b/image-classification/problem_unittests.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 
 def _print_success_message():
-    return print('Tests Passed')
+    print('Tests Passed')
 
 
 def test_folder_path(cifar10_dataset_folder_path):


### PR DESCRIPTION
I would remove the `return` from this function definition.

In Python 2, this is a syntax error unless you do a `from __future__ import print_function` before other imports at the top of your file. In Python 3 or in Python 2 in print_function mode, print(x) will always return None.