### PR TITLE
Only allow TensorFlow 1.0 language translation project

### DIFF
--- a/language-translation/dlnd_language_translation.ipynb
+++ b/language-translation/dlnd_language_translation.ipynb
@@ -212,7 +212,7 @@
     "import tensorflow as tf\n",
     "\n",
     "# Check TensorFlow Version\n",
-    "assert LooseVersion(tf.__version__) >= LooseVersion('1.0'), 'Please use TensorFlow version 1.0 or newer'\n",
+    "assert LooseVersion(tf.__version__) == LooseVersion('1.0.0'), 'This project requires TensorFlow version 1.0  You are using {}'.format(tf.__version__)\n",
     "print('TensorFlow Version: {}'.format(tf.__version__))\n",
     "\n",
     "# Check for a GPU\n",


### PR DESCRIPTION
TensorFlow 1.1 removes sequence to sequence apis used in this project.