### PR TITLE
Use `with open()` to avoid leaking file handles

### DIFF
--- a/language-translation/helper.py
+++ b/language-translation/helper.py
@@ -13,9 +13,7 @@ def load_data(path):
     """
     input_file = os.path.join(path)
     with open(input_file, 'r', encoding='utf-8') as f:
-        data = f.read()
-
-    return data
+        return f.read()
 
 
 def preprocess_and_save_data(source_path, target_path, text_to_ids):
@@ -35,17 +33,19 @@ def preprocess_and_save_data(source_path, target_path, text_to_ids):
     source_text, target_text = text_to_ids(source_text, target_text, source_vocab_to_int, target_vocab_to_int)
 
     # Save Data
-    pickle.dump((
-        (source_text, target_text),
-        (source_vocab_to_int, target_vocab_to_int),
-        (source_int_to_vocab, target_int_to_vocab)), open('preprocess.p', 'wb'))
+    with open('preprocess.p', 'wb') as out_file:
+        pickle.dump((
+            (source_text, target_text),
+            (source_vocab_to_int, target_vocab_to_int),
+            (source_int_to_vocab, target_int_to_vocab)), out_file)
 
 
 def load_preprocess():
     """
     Load the Preprocessed Training data and return them in batches of <batch_size> or less
     """
-    return pickle.load(open('preprocess.p', mode='rb'))
+    with open('preprocess.p', mode='rb') as in_file:
+        return pickle.load(in_file)
 
 
 def create_lookup_tables(text):
@@ -67,14 +67,16 @@ def save_params(params):
     """
     Save parameters to file
     """
-    pickle.dump(params, open('params.p', 'wb'))
+    with open('params.p', 'wb') as out_file:
+        pickle.dump(params, out_file)
 
 
 def load_params():
     """
     Load parameters from file
     """
-    return pickle.load(open('params.p', mode='rb'))
+    with open('params.p', mode='rb') as in_file:
+        return pickle.load(in_file)
 
 
 def batch_data(source, target, batch_size):


### PR DESCRIPTION
Different implementations of Python will [do different things](http://blog.lerner.co.il/dont-use-python-close-files-answer-depends/) with files not closed so explicit is better than implicit especially on file writes.