### PR TITLE
Fix issue with reuse not being properly passed

### DIFF
--- a/gan_mnist/Intro_to_GANs_Exercises.ipynb
+++ b/gan_mnist/Intro_to_GANs_Exercises.ipynb
@@ -539,7 +539,7 @@
     "    gen_samples, _ = sess.run(\n",
     "                   generator(input_z, input_size, reuse=True),\n",
     "                   feed_dict={input_z: sample_z})\n",
-    "view_samples([gen_samples], 0)"
+    "view_samples(0, [gen_samples])"
    ]
   }
  ],

--- a/gan_mnist/Intro_to_GANs_Exercises.ipynb
+++ b/gan_mnist/Intro_to_GANs_Exercises.ipynb
@@ -383,7 +383,7 @@
     "        # Sample from generator as we're training for viewing afterwards\n",
     "        sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "        gen_samples, _ = sess.run(\n",
-    "                       generator(input_z, input_size, True),\n",
+    "                       generator(input_z, input_size, reuse=True),\n",
     "                       feed_dict={input_z: sample_z})\n",
     "        samples.append(gen_samples)\n",
     "        saver.save(sess, './checkpoints/generator.ckpt')\n",
@@ -537,7 +537,7 @@
     "    saver.restore(sess, tf.train.latest_checkpoint('checkpoints'))\n",
     "    sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "    gen_samples, _ = sess.run(\n",
-    "                   generator(input_z, input_size, True),\n",
+    "                   generator(input_z, input_size, reuse=True),\n",
     "                   feed_dict={input_z: sample_z})\n",
     "view_samples([gen_samples], 0)"
    ]


### PR DESCRIPTION
The code passes `True` as a 3rd positional argument to `generator()`. It is intended to set `reuse` (which is actually the 4th positional argument), but is actually passed as `n_units`. This results in `n_units` being set to 1 (`True` is implicitly converted to 1 behind the scenes) and `reuse` remaining `False`. This in turn results in an exception during training. The issue was already fixed in the solution notebook, this commit fixes this for the exercise notebook.