### PR TITLE
correct a reference to generator in a task description

### DIFF
--- a/face_generation/dlnd_face_generation.ipynb
+++ b/face_generation/dlnd_face_generation.ipynb
@@ -218,7 +218,7 @@
    },
    "source": [
     "### Discriminator\n",
-    "Implement `discriminator` to create a discriminator neural network that discriminates on `images`.  This function should be able to reuse the variabes in the neural network.  Use [`tf.variable_scope`](https://www.tensorflow.org/api_docs/python/tf/variable_scope) with a scope name of \"discriminator\" to allow the variables to be reused.  The function should return a tuple of (tensor output of the generator, tensor logits of the generator)."
+    "Implement `discriminator` to create a discriminator neural network that discriminates on `images`.  This function should be able to reuse the variabes in the neural network.  Use [`tf.variable_scope`](https://www.tensorflow.org/api_docs/python/tf/variable_scope) with a scope name of \"discriminator\" to allow the variables to be reused.  The function should return a tuple of (tensor output of the discriminator, tensor logits of the discriminator)."
    ]
   },
   {


### PR DESCRIPTION
the instructions reference `generator` when they should reference `discriminator`.