### PR TITLE
Adding n_units and alpha parameters to generator call function

### DIFF
--- a/gan_mnist/Intro_to_GANs_Exercises.ipynb
+++ b/gan_mnist/Intro_to_GANs_Exercises.ipynb
@@ -387,7 +387,7 @@
     "        # Sample from generator as we're training for viewing afterwards\n",
     "        sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "        gen_samples = sess.run(\n",
-    "                       generator(input_z, input_size, reuse=True),\n",
+    "                       generator(input_z, input_size, n_units=g_hidden_size, reuse=True, alpha=alpha),\n",
     "                       feed_dict={input_z: sample_z})\n",
     "        samples.append(gen_samples)\n",
     "        saver.save(sess, './checkpoints/generator.ckpt')\n",
@@ -547,7 +547,7 @@
     "    saver.restore(sess, tf.train.latest_checkpoint('checkpoints'))\n",
     "    sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "    gen_samples = sess.run(\n",
-    "                   generator(input_z, input_size, reuse=True),\n",
+    "                   generator(input_z, input_size, n_units=g_hidden_size, reuse=True, alpha=alpha),\n",
     "                   feed_dict={input_z: sample_z})\n",
     "view_samples(0, [gen_samples])"
    ]

--- a/gan_mnist/Intro_to_GANs_Solution.ipynb
+++ b/gan_mnist/Intro_to_GANs_Solution.ipynb
@@ -361,7 +361,7 @@
     "        # Sample from generator as we're training for viewing afterwards\n",
     "        sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "        gen_samples = sess.run(\n",
-    "                       generator(input_z, input_size, reuse=True),\n",
+    "                       generator(input_z, input_size, n_units=g_hidden_size, reuse=True, alpha=alpha),\n",
     "                       feed_dict={input_z: sample_z})\n",
     "        samples.append(gen_samples)\n",
     "        saver.save(sess, './checkpoints/generator.ckpt')\n",
@@ -554,7 +554,7 @@
     "    saver.restore(sess, tf.train.latest_checkpoint('checkpoints'))\n",
     "    sample_z = np.random.uniform(-1, 1, size=(16, z_size))\n",
     "    gen_samples = sess.run(\n",
-    "                   generator(input_z, input_size, reuse=True),\n",
+    "                   generator(input_z, input_size, n_units=g_hidden_size, reuse=True, alpha=alpha),\n",
     "                   feed_dict={input_z: sample_z})\n",
     "_ = view_samples(0, [gen_samples])"
    ]


### PR DESCRIPTION
The generator function calls during training and sampling were using the default parameters. This causes an issue when specifying different hyperparameter values for g_hidden_size and alpha