### PR TITLE
tv-script-generation: Fix test_get_init_cell for TensorFlow 1.2 (#334)

### DIFF
--- a/tv-script-generation/problem_unittests.py
+++ b/tv-script-generation/problem_unittests.py
@@ -182,7 +182,7 @@ def test_get_inputs(get_inputs):
 
 def test_get_init_cell(get_init_cell):
     with tf.Graph().as_default():
-        test_batch_size_ph = tf.placeholder(tf.int32)
+        test_batch_size_ph = tf.placeholder(tf.int32, [])
         test_rnn_size = 256
 
         cell, init_state = get_init_cell(test_batch_size_ph, test_rnn_size)


### PR DESCRIPTION
```
initial_state = cell.zero_state(batch_size, tf.float32)
```

returned the following error with TensorFlow 1.2:

```
ValueError: prefix tensor must be either a scalar or vector, but saw
tensor: Tensor("Placeholder:0", dtype=int32)
```

As suggested in udacity/dlnd-issue-reports#334 and tensorflow/tensorflow#10213, it seems we
should use `tf.placeholder(tf.int32, [])` instead.

I've confirmed that the change works for TensorFlow 1.0.