### PR TITLE
to_categorical parameters correction

### DIFF
--- a/intro-to-tflearn/TFLearn_Sentiment_Analysis.ipynb
+++ b/intro-to-tflearn/TFLearn_Sentiment_Analysis.ipynb
@@ -237,7 +237,8 @@
    "source": [
     "### Train, Validation, Test sets\n",
     "\n",
-    "Now that we have the word_vectors, we're ready to split our data into train, validation, and test sets. Remember that we train on the train data, use the validation data to set the hyperparameters, and at the very end measure the network performance on the test data. Here we're using the function `to_categorical` from TFLearn to reshape the target data so that we'll have two output units and can classify with a softmax activation function. We actually won't be creating the validation set here, TFLearn will do that for us later."
+    "Now that we have the word_vectors, we're ready to split our data into train, validation, and test sets. Remember that we train on the train data, use the validation data to set the hyperparameters, and at the very end measure the network performance on the test data. Here we're using the function `
+    (` from TFLearn to reshape the target data so that we'll have two output units and can classify with a softmax activation function. We actually won't be creating the validation set here, TFLearn will do that for us later."
    ]
   },
   {
@@ -256,8 +257,8 @@
     "test_fraction = 0.9\n",
     "\n",
     "train_split, test_split = shuffle[:int(records*test_fraction)], shuffle[int(records*test_fraction):]\n",
-    "trainX, trainY = word_vectors[train_split,:], to_categorical(Y.values[train_split], 2)\n",
-    "testX, testY = word_vectors[test_split,:], to_categorical(Y.values[test_split], 2)"
+    "trainX, trainY = word_vectors[train_split,:], to_categorical(list(Y[0].values[train_split]),  nb_classes=2)\n",
+    "testX, testY = word_vectors[test_split,:], to_categorical(list(Y[0].values[test_split]),  nb_classes=2)"
    ]
   },
   {


### PR DESCRIPTION
I think inputs to to_categorical method should be coded this way. If you try testing the value of trainY in the notebook that was provided to students. It is not printing correct binary matrices for trainY & testY.

I have made some changes to the code, kindly review it and make these changes in the notebook.