### PR TITLE
docs: tv-script-gen fixes spelling of "forms" to "forums"

### DIFF
--- a/tv-script-generation/dlnd_tv_script_generation.ipynb
+++ b/tv-script-generation/dlnd_tv_script_generation.ipynb
@@ -674,7 +674,7 @@
    },
    "source": [
     "## Train\n",
-    "Train the neural network on the preprocessed data.  If you have a hard time getting a good loss, check the [forms](https://discussions.udacity.com/) to see if anyone is having the same problem."
+    "Train the neural network on the preprocessed data.  If you have a hard time getting a good loss, check the [forums](https://discussions.udacity.com/) to see if anyone is having the same problem."
    ]
   },
   {


### PR DESCRIPTION
swaps out "forms" for "forums"

Context: "Train the neural network on the preprocessed data.  If you have a hard time getting a good loss, check the [forms](https://discussions.udacity.com/) to see if anyone is having the same problem."