### PR TITLE
Lang translation: Fixed name, `max_summary_length`

### DIFF
--- a/language-translation/dlnd_language_translation.ipynb
+++ b/language-translation/dlnd_language_translation.ipynb
@@ -329,7 +329,7 @@
    "source": [
     "\n",
     "def decoding_layer_train(encoder_state, dec_cell, dec_embed_input, \n",
-    "                         target_sequence_length, max_summary_length, \n",
+    "                         target_sequence_length, max_translation_length, \n",
     "                         output_layer, keep_prob):\n",
     "    \"\"\"\n",
     "    Create a decoding layer for training\n",
@@ -337,7 +337,7 @@
     "    :param dec_cell: Decoder RNN Cell\n",
     "    :param dec_embed_input: Decoder embedded input\n",
     "    :param target_sequence_length: The lengths of each sequence in the target batch\n",
-    "    :param max_summary_length: The length of the longest sequence in the batch\n",
+    "    :param max_translation_length: The length of the longest sequence in the batch\n",
     "    :param output_layer: Function to apply the output layer\n",
     "    :param keep_prob: Dropout keep probability\n",
     "    :return: BasicDecoderOutput containing training logits and sample_id\n",


### PR DESCRIPTION
Fixed, was `max_summary_length`, corrected to `max_translation_length`
in `decoding_layer_train`