### PR TITLE
Language Translation: removed zombie comment

### DIFF
--- a/language-translation/dlnd_language_translation.ipynb
+++ b/language-translation/dlnd_language_translation.ipynb
@@ -384,7 +384,6 @@
     "    :param end_of_sequence_id: EOS Id\n",
     "    :param max_target_sequence_length: Maximum length of target sequences\n",
     "    :param vocab_size: Size of decoder/target vocabulary\n",
-    "    :param decoding_scope: TenorFlow Variable Scope for decoding\n",
     "    :param output_layer: Function to apply the output layer\n",
     "    :param batch_size: Batch size\n",
     "    :param keep_prob: Dropout keep probability\n",


### PR DESCRIPTION
`decoding_scope` was removed from parameters list to `decoding_layer_infer`.

I'm guessing the markers might still have the old version, based on the feedback I got for my submission.
The assignment can still be completed, in `decoding_layer`, requiring use of `    with tf.variable_scope("decode"):` and `    with tf.variable_scope("decode", reuse=True):`.