### PR TITLE
GAN_mnist: fix `generator` return doc

### DIFF
--- a/gan_mnist/Intro_to_GANs_Exercises.ipynb
+++ b/gan_mnist/Intro_to_GANs_Exercises.ipynb
@@ -133,7 +133,7 @@
     "        \n",
     "        Returns\n",
     "        -------\n",
-    "        out, logits: \n",
+    "        out: \n",
     "    '''\n",
     "    with tf.variable_scope # finish this\n",
     "        # Hidden layer\n",


### PR DESCRIPTION
Remove `logits` from return doc, since it isn't actually returned.