### PR TITLE
dcgan-svhn: Fixed so that alpha isn't ignored

### DIFF
--- a/dcgan-svhn/DCGAN.ipynb
+++ b/dcgan-svhn/DCGAN.ipynb
@@ -444,7 +444,7 @@
     "        self.input_real, self.input_z = model_inputs(real_size, z_size)\n",
     "        \n",
     "        self.d_loss, self.g_loss = model_loss(self.input_real, self.input_z,\n",
-    "                                              real_size[2], alpha=0.2)\n",
+    "                                              real_size[2], alpha=alpha)\n",
     "        \n",
     "        self.d_opt, self.g_opt = model_opt(self.d_loss, self.g_loss, learning_rate, beta1)"
    ]

--- a/dcgan-svhn/DCGAN_Exercises.ipynb
+++ b/dcgan-svhn/DCGAN_Exercises.ipynb
@@ -403,7 +403,7 @@
     "        self.input_real, self.input_z = model_inputs(real_size, z_size)\n",
     "        \n",
     "        self.d_loss, self.g_loss = model_loss(self.input_real, self.input_z,\n",
-    "                                              real_size[2], alpha=0.2)\n",
+    "                                              real_size[2], alpha=alpha)\n",
     "        \n",
     "        self.d_opt, self.g_opt = model_opt(self.d_loss, self.g_loss, learning_rate, beta1)"
    ]


### PR DESCRIPTION
`alpha` passed to `GAN` class constructor was being ignored.  Fixed it.