### PR TITLE
Fix `trainY` and `testY` in Project notebook

### DIFF
--- a/intro-to-tflearn/TFLearn_Sentiment_Analysis.ipynb
+++ b/intro-to-tflearn/TFLearn_Sentiment_Analysis.ipynb
@@ -256,8 +256,8 @@
     "test_fraction = 0.9\n",
     "\n",
     "train_split, test_split = shuffle[:int(records*test_fraction)], shuffle[int(records*test_fraction):]\n",
-    "trainX, trainY = word_vectors[train_split,:], to_categorical(Y.values[train_split], 2)\n",
-    "testX, testY = word_vectors[test_split,:], to_categorical(Y.values[test_split], 2)"
+    "trainX, trainY = word_vectors[train_split,:], to_categorical(Y.values[train_split, 0], 2)\n",
+    "testX, testY = word_vectors[test_split,:], to_categorical(Y.values[test_split, 0], 2)"
    ]
   },
   {


### PR DESCRIPTION
The `trainY` and `textY` ndarrays were being generated incorrectly due to the values not being passed correctly to `to_categorical`.