### PR TITLE
Fix skipped layer in semi-supervised learning lesson

### DIFF
--- a/semi-supervised/semi-supervised_learning_2.ipynb
+++ b/semi-supervised/semi-supervised_learning_2.ipynb
@@ -282,7 +282,7 @@
     "        relu6 = tf.maximum(alpha * bn6, bn6)\n",
     "        relu6 = tf.layers.dropout(relu6, rate=drop_rate)\n",
     "        \n",
-    "        x7 = tf.layers.conv2d(relu5, 2 * size_mult, 3, strides=1, padding='valid')\n",
+    "        x7 = tf.layers.conv2d(relu6, 2 * size_mult, 3, strides=1, padding='valid')\n",
     "        # Don't use bn on this layer, because bn would set the mean of each feature\n",
     "        # to the bn mu parameter.\n",
     "        # This layer is used for the feature matching loss, which only works if\n",


### PR DESCRIPTION
This seems to be a coding mistake that skips a layer in the Discriminator. If that's correct, then it should be fixed in the solution notebook as well.