### PR TITLE
Update floydhub reference for image-classification

### DIFF
--- a/image-classification/README.md
+++ b/image-classification/README.md
@@ -33,7 +33,7 @@ You are not required to use FloydHub for this project, but we've provided instru
 
 7. Wait for the Jupyter notebook to become available and then access the URL displayed in the terminal (described as "path to jupyter notebook"). You will see the notebook.
 
-8. Remember to explicitly stop the experiment when you are not using the notebook. As long as it runs (even in the background) it will cost GPU hours. You can stop an experiment in the ["Experiments" section on floyd.com](https://www.floydhub.com/experiments) or using the [floyd stop](https://docs.floydhub.com/guides/stop_job/) command.
+8. Remember to explicitly stop the job when you are not using the notebook. As long as it runs (even in the background) it will cost GPU hours. You can stop a job in the ["Jobs" section on floyd.com](https://www.floydhub.com/jobs) or using the [floyd stop](https://docs.floydhub.com/guides/stop_job/) command.
 
 **Important:** When you run a project it will always start from scratch (i.e. from the state present *locally* on your computer). If you made changes in the remote jupiter notebook during a previous run, the changes will **not** be present in subsequent runs. To make them permanent you need to add the changes to your local project folder. When running the notebook you can download them directly from Jupyter - *File / Download / Notebook*. After downloading it, just replace your local `dlnd_image_classification.ipynb` file with the newly downloaded one.
 

--- a/image-classification/README.md
+++ b/image-classification/README.md
@@ -7,7 +7,7 @@ You are not required to use FloydHub for this project, but we've provided instru
 2. Install the `floyd` command on your computer:
 
         pip install -U floyd-cli
-        
+
     Do this even if you already installed `floyd-cli` before, just to make sure you have the most recent version (Its pace of development is fast!).
 
 3. Associate the command with your Floyd account:
@@ -30,21 +30,13 @@ You are not required to use FloydHub for this project, but we've provided instru
         floyd run --data mat_udacity/datasets/udacity-cifar-10/1:cifar --mode jupyter --gpu --env tensorflow-1.2
 
     It will be run on a machine with GPU (`--gpu`), using a Tenserflow environment (`--env tensorflow-1.2`), as a Jupyter notebook (`--mode jupyter`), with the cifar-10 dataset available (`--data mat_udacity/datasets/udacity-cifar-10/1:cifar`).
-    
+
 7. Wait for the Jupyter notebook to become available and then access the URL displayed in the terminal (described as "path to jupyter notebook"). You will see the notebook.
 
-8. Remember to explicitly stop the experiment when you are not using the notebook. As long as it runs (even in the background) it will cost GPU hours. You can stop an experiment in the ["Experiments" section on floyd.com](https://www.floydhub.com/experiments) or using the `floyd stop` command:
+8. Remember to explicitly stop the experiment when you are not using the notebook. As long as it runs (even in the background) it will cost GPU hours. You can stop an experiment in the ["Experiments" section on floyd.com](https://www.floydhub.com/experiments) or using the [floyd stop](https://docs.floydhub.com/guides/stop_job/) command.
 
-        floyd stop ID
- 
-    (where ID is the "RUN ID" displayed in the terminal when you run the project; if you lost it you can also find it in the ["Experiments" section on floyd.com](https://www.floydhub.com/experiments))
-    
 **Important:** When you run a project it will always start from scratch (i.e. from the state present *locally* on your computer). If you made changes in the remote jupiter notebook during a previous run, the changes will **not** be present in subsequent runs. To make them permanent you need to add the changes to your local project folder. When running the notebook you can download them directly from Jupyter - *File / Download / Notebook*. After downloading it, just replace your local `dlnd_image_classification.ipynb` file with the newly downloaded one.
 
-Alternatively, If you already stoped the experiment, you can still download the file using the `floyd output` command:
+Alternatively, If you already stoped the experiment, you can still download the file using the [floyd output](https://docs.floydhub.com/commands/output/) command.
 
-    floyd output ID
-
-(where ID is the "RUN ID" displayed in the terminal when you run the project; if you lost it you can also find it in the ["Experiments" section on floyd.com](https://www.floydhub.com/experiments))
-    
 Just run the command above, download `dlnd_image_classification.ipynb` and replace your local version with the newly downloaded one.


### PR DESCRIPTION
Hi Udacity's Team. Here's my update for the `image-classification/README.md`:

- Update job reference(replaced experiment)
- Replace `floyd-command ID` with link to our official docs

Best,
Alessio of FloydHub