### PR TITLE
Explicitly specify encoding in open file

### DIFF
--- a/tv-script-generation/helper.py
+++ b/tv-script-generation/helper.py
@@ -7,7 +7,7 @@ def load_data(path):
     Load Dataset from File
     """
     input_file = os.path.join(path)
-    with open(input_file, "r") as f:
+    with open(input_file, "r", encoding="cp1252") as f:
         data = f.read()
 
     return data


### PR DESCRIPTION
Without this change, I ran into UnicodeDecodeError in python 3.5.2. I believe this is because newer versions of python support multiple enocdings, and may not choose the correct encoding by default. Specifying the encoding explicitly I think should fix the problem always.