### PR TITLE
Fixed the DeprecationWarning while training

### DIFF
--- a/first-neural-network/Your_first_neural_network.ipynb
+++ b/first-neural-network/Your_first_neural_network.ipynb
@@ -358,7 +358,7 @@
     "for ii in range(iterations):\n",
     "    # Go through a random batch of 128 records from the training data set\n",
     "    batch = np.random.choice(train_features.index, size=128)\n",
-    "    X, y = train_features.ix[batch].values, train_targets.ix[batch]['cnt']\n",
+    "    X, y = train_features.loc[batch].values, train_targets.loc[batch]['cnt']\n",
     "                             \n",
     "    network.train(X, y)\n",
     "    \n",


### PR DESCRIPTION
The issue of DeprecationWarning can be fixed by replacing .ix with .loc in the following line:
`X, y = train_features.loc[batch].values, train_targets.loc[batch]['cnt']`