### PR TITLE
gan_mnist: fix label generation for d_loss_fake

### DIFF
--- a/gan_mnist/Intro_to_GANs_Solution.ipynb
+++ b/gan_mnist/Intro_to_GANs_Solution.ipynb
@@ -265,7 +265,7 @@
     "                                                          labels=tf.ones_like(d_logits_real) * (1 - smooth)))\n",
     "d_loss_fake = tf.reduce_mean(\n",
     "                  tf.nn.sigmoid_cross_entropy_with_logits(logits=d_logits_fake, \n",
-    "                                                          labels=tf.zeros_like(d_logits_real)))\n",
+    "                                                          labels=tf.zeros_like(d_logits_fake)))\n",
     "d_loss = d_loss_real + d_loss_fake\n",
     "\n",
     "g_loss = tf.reduce_mean(\n",


### PR DESCRIPTION
The previous code worked in spite of the typo, because the current version of the training code sets up the two tensors to have the same shape.