### PR TITLE
Locks tf version to fix type error during import

### DIFF
--- a/intro-to-tensorflow/environment.yml
+++ b/intro-to-tensorflow/environment.yml
@@ -50,7 +50,7 @@ dependencies:
   - simplegeneric==0.8.1
   - six==1.10.0
   - sklearn==0.0
-  - tensorflow>=0.12.1
+  - tensorflow==0.12.1
   - terminado==0.6
   - tornado==4.4.2
   - tqdm==4.8.4


### PR DESCRIPTION
See [this](https://github.com/udacity/deep-learning/issues/259) issue for an explanation of why I'm making this PR.