### PR TITLE
Freshly cloned notebook throws pyplot.imshow error fourth cell from top

### DIFF
--- a/face_generation/dlnd_face_generation.ipynb
+++ b/face_generation/dlnd_face_generation.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "# Face Generation\n",
@@ -23,9 +27,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -48,7 +57,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Explore the Data\n",
@@ -60,9 +73,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -77,14 +95,18 @@
     "from matplotlib import pyplot\n",
     "\n",
     "mnist_images = helper.get_batch(glob(os.path.join(data_dir, 'mnist/*.jpg'))[:show_n_images], 28, 28, 'L')\n",
-    "pyplot.imshow(helper.images_square_grid(mnist_images, 'L'), cmap='gray')"
+    "pyplot.imshow(helper.images_square_grid(mnist_images, 'L').convert(\"RGB\"), cmap='gray')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### CelebA\n",
@@ -95,9 +117,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -114,7 +141,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Preprocess the Data\n",
@@ -138,9 +169,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -166,7 +202,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Input\n",
@@ -182,9 +222,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -214,7 +259,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Discriminator\n",
@@ -225,9 +274,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -253,7 +307,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Generator\n",
@@ -264,9 +322,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -293,7 +356,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Loss\n",
@@ -306,9 +373,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -335,7 +407,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Optimization\n",
@@ -346,9 +422,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -376,7 +457,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Neural Network Training\n",
@@ -388,9 +473,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "autoscroll": false,
+    "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -425,7 +515,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Train\n",
@@ -441,9 +535,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "autoscroll": false,
+    "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -475,7 +574,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### MNIST\n",
@@ -486,10 +589,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
     "editable": true,
-    "scrolled": true
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -514,7 +622,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### CelebA\n",
@@ -525,10 +637,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
     "editable": true,
-    "scrolled": true
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -553,7 +670,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Submitting This Project\n",
@@ -564,7 +685,6 @@
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -578,7 +698,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  }
+  },
+  "name": "dlnd_face_generation.ipynb"
  },
  "nbformat": 4,
  "nbformat_minor": 0


### PR DESCRIPTION
After cloning the repo and running the first four cells, cell four does not
plot the sample of 25 images. The error thrown is same as in this discussion

https://github.com/matplotlib/matplotlib/issues/10616/

Work around:

pyplot.imshow(helper.images_square_grid(mnist_images, 'L'), cmap='gray')

replaced by;

pyplot.imshow(helper.images_square_grid(mnist_images, 'L').convert("RGB"), cmap='gray')