### PR TITLE
    fix: Set *reuse* as named parameter for generator function

### DIFF
--- a/face_generation/dlnd_face_generation.ipynb
+++ b/face_generation/dlnd_face_generation.ipynb
@@ -3,8 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -28,9 +26,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -56,8 +51,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -74,9 +67,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -101,8 +91,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -118,9 +106,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -140,8 +125,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -170,9 +153,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -201,8 +181,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -223,9 +201,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -258,8 +233,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -275,9 +248,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -306,8 +276,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -323,9 +291,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -333,7 +298,7 @@
    },
    "outputs": [],
    "source": [
-    "def generator(z, out_channel_dim, is_train=True):\n",
+    "def generator(z, out_channel_dim, reuse=False, is_train=True):\n",
     "    \"\"\"\n",
     "    Create the generator network\n",
     "    :param z: Input z\n",
@@ -355,8 +320,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -374,9 +337,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -406,8 +366,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -423,9 +381,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -456,8 +411,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -474,9 +427,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -514,8 +464,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -536,9 +484,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -573,8 +518,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -590,9 +533,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "scrolled": true,
     "slideshow": {
@@ -621,8 +561,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -638,9 +576,6 @@
    "execution_count": null,
    "metadata": {
     "autoscroll": false,
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "scrolled": true,
     "slideshow": {
@@ -669,8 +604,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "ein.tags": "worksheet-0",
     "slideshow": {
      "slide_type": "-"
@@ -685,6 +618,7 @@
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -697,10 +631,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.1"
   },
   "name": "dlnd_face_generation.ipynb"
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/face_generation/dlnd_face_generation.ipynb
+++ b/face_generation/dlnd_face_generation.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "# Face Generation\n",
@@ -23,9 +27,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -48,7 +57,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Explore the Data\n",
@@ -60,9 +73,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -77,14 +95,18 @@
     "from matplotlib import pyplot\n",
     "\n",
     "mnist_images = helper.get_batch(glob(os.path.join(data_dir, 'mnist/*.jpg'))[:show_n_images], 28, 28, 'L')\n",
-    "pyplot.imshow(helper.images_square_grid(mnist_images, 'L'), cmap='gray')"
+    "pyplot.imshow(helper.images_square_grid(mnist_images, 'L').convert(\"RGB\"), cmap='gray')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### CelebA\n",
@@ -95,9 +117,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -114,7 +141,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Preprocess the Data\n",
@@ -138,9 +169,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -166,7 +202,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Input\n",
@@ -182,9 +222,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -214,7 +259,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Discriminator\n",
@@ -225,9 +274,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -253,7 +307,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Generator\n",
@@ -264,9 +322,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -293,7 +356,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Loss\n",
@@ -306,9 +373,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -335,7 +407,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Optimization\n",
@@ -346,9 +422,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -376,7 +457,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "## Neural Network Training\n",
@@ -388,9 +473,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "autoscroll": false,
+    "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -425,7 +515,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Train\n",
@@ -441,9 +535,14 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "autoscroll": false,
+    "collapsed": false,
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -475,7 +574,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### MNIST\n",
@@ -486,10 +589,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
     "editable": true,
-    "scrolled": true
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -514,7 +622,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### CelebA\n",
@@ -525,10 +637,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "autoscroll": false,
     "collapsed": false,
     "deletable": true,
     "editable": true,
-    "scrolled": true
+    "ein.tags": "worksheet-0",
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "outputs": [],
    "source": [
@@ -553,7 +670,11 @@
    "cell_type": "markdown",
    "metadata": {
     "deletable": true,
-    "editable": true
+    "editable": true,
+    "ein.tags": "worksheet-0",
+    "slideshow": {
+     "slide_type": "-"
+    }
    },
    "source": [
     "### Submitting This Project\n",
@@ -564,7 +685,6 @@
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
-   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -578,7 +698,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.2"
-  }
+  },
+  "name": "dlnd_face_generation.ipynb"
  },
  "nbformat": 4,
  "nbformat_minor": 0

--- a/face_generation/problem_unittests.py
+++ b/face_generation/problem_unittests.py
@@ -106,7 +106,7 @@ def test_generator(generator, tf_module):
             'tf.variable_scope called with wrong arguments in Generator Training(reuse=false)'
 
         mock_variable_scope.reset_mock()
-        output = generator(z, out_channel_dim, False)
+        output = generator(z, out_channel_dim, reuse=True)
         _assert_tensor_shape(output, [None, 28, 28, out_channel_dim], 'Generator output (is_train=False)')
         assert mock_variable_scope.called, \
             'tf.variable_scope not called in Generator Inference(reuse=True)'


### PR DESCRIPTION
    Test for the generator function in problem_unittests.py uses the
    function inconsistently, calling it with *reuse* as a positional parameter
    in one case, and as a named parameter in another (when omitting to pass
    any value for it). Also, the calls seemed to be flipped, with the assertion
    for the case of reuse=True actually testing for reuse==False.