### PR TITLE
fix: Force convert output of images_square_grid to RGB

### DIFF
--- a/face_generation/helper.py
+++ b/face_generation/helper.py
@@ -121,7 +121,7 @@ def images_square_grid(images, mode):
             im = Image.fromarray(image, mode)
             new_im.paste(im, (col_i * images.shape[1], image_i * images.shape[2]))
 
-    return new_im
+    return new_im.convert('RGB')
 
 
 def download_extract(database_name, data_path):


### PR DESCRIPTION
After cloning the repo and running the first four cells, cell four does not
plot the sample of 25 images. The error thrown is same as in this discussion

https://github.com/matplotlib/matplotlib/issues/10616

The problem arises when helper function images_square_grid is called under
'L' mode.