### PR TITLE
Fix the image width so that it is rendered properly

### DIFF
--- a/first-neural-network/Your_first_neural_network.ipynb
+++ b/first-neural-network/Your_first_neural_network.ipynb
@@ -194,7 +194,7 @@
     "\n",
     "Below you'll build your network. We've built out the structure. You'll implement both the forward pass and backwards pass through the network. You'll also set the hyperparameters: the learning rate, the number of hidden units, and the number of training passes.\n",
     "\n",
-    "<img src=\"assets/neural_network.png\" width=300px>\n",
+    "<img src=\"assets/neural_network.png\" width=\"300\">\n",
     "\n",
     "The network has two layers, a hidden layer and an output layer. The hidden layer will use the sigmoid function for activations. The output layer has only one node and is used for the regression, the output of the node is the same as the input of the node. That is, the activation function is $f(x)=x$. A function that takes the input signal and generates an output signal, but takes into account the threshold, is called an activation function. We work through each layer of our network calculating the outputs for each neuron. All of the outputs from one layer become inputs to the neurons on the next layer. This process is called *forward propagation*.\n",
     "\n",


### PR DESCRIPTION
Github requires widths to be specified in quotes, or else the image isn't rendered. This PR fixes it.

Check here (under `Time to build the network`): [link](https://github.com/udacity/deep-learning/blob/05dbe4136cca84858002e625a977966183f1e992/first-neural-network/Your_first_neural_network.ipynb)

And check the patch: [link](https://github.com/avinassh/deep-learning/blob/patch-1/first-neural-network/Your_first_neural_network.ipynb)

