### PR TITLE
Fix: Correct Error Term Formula Implementation

### DIFF
--- a/student-admissions/StudentAdmissionsSolutions.ipynb
+++ b/student-admissions/StudentAdmissionsSolutions.ipynb
@@ -71,8 +71,8 @@
    },
    "outputs": [],
    "source": [
-    "def error_term_formula(y, output):\n",
-    "    return (y-output) * output * (1 - output)"
+    "def error_term_formula(x, y, output):\n",
+    "    return (y - output)*(sigmoid_prime(x))"
    ]
   }
  ],


### PR DESCRIPTION
The Error Term Formula was implemented wrongly and this can confuse students.